### PR TITLE
Enable CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,10 @@ machine:
 jobs:
   build:
     docker:
-      - image: circleci/node:8.5.0
+      # Using latest LTS available on CircleCI
+      - image: circleci/node:8.11.2-browsers
+        environment:
+          - CHROME_BIN: /usr/bin/google-chrome
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+machine:
+  node:
+    version: stable
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.5.0
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run: npm run lint
+
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ except according to the terms contained in the LICENSE file.
 -->
 # ODK Central Frontend
 
+![Platform](https://img.shields.io/badge/platform-Vue.js-blue.svg)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Build status](https://circleci.com/gh/opendatakit/central-frontend.svg?style=shield)](https://circleci.com/gh/opendatakit/central-frontend)
 
 ODK Central Frontend uses Vue.js to provide the frontend for [ODK Central](https://github.com/opendatakit/central). It is currently under development.
 


### PR DESCRIPTION
Closes #14 

I started with node 8.5, same as the backend, but the tests wouldn't pass. Once I switched to the latest available node LTS (currently 8.11.2), it worked. 