### PR TITLE
Bump node-sass to latest now that they have resolved `npm audit` warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6165,9 +6165,9 @@
       }
     },
     "node-sass": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.6.1.tgz",
-      "integrity": "sha512-0zQQ7tjEK5W8RfW9LiQrkzfo7uLZ0QtZGV69rdKn5cFzdweHLJ14lR6xLPvI6UimkXMO8m0qDsXwUCNdnqV3sA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.1.tgz",
+      "integrity": "sha512-m6H1I6cHXsHsJ7BIWdnJsz9S9gVMyh+/H2cOTXgl2/2WqyyWlBcl4PHJcqrXo5RZVCfCUFqOtjPN0+0XbVHR5Q==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -6182,12 +6182,13 @@
         "lodash.mergewith": "^4.6.0",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.3.2",
+        "nan": "^2.10.0",
         "node-gyp": "^3.3.1",
         "npmlog": "^4.0.0",
-        "request": "^2.79.0",
+        "request": "2.87.0",
         "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0"
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "lodash.assign": {
@@ -8668,6 +8669,30 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "true-case-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+      "dev": true,
+      "requires": {
+        "glob": "^6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
     },
     "tsscmp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "karma-spec-reporter": "0.0.32",
     "mocha": "~5.2",
     "node-gyp": "3.6.2",
-    "node-sass": "~4.6",
+    "node-sass": "~4.9",
     "proxyquireify": "~3.2",
     "should": "~13.2",
     "uglify-js": "~2.8",


### PR DESCRIPTION
The latest version of node-sass now uses request 2.87, which apparently
resolves the `npm audit` warning.

I think we have to continue pinning node-gyp for now, but I am hoping
that node-gyp will similarly upgrade to request 2.87 soon. Once that
occurs, we should be able to remove it as a dev dependency.