### PR TITLE
Replace .table with .panel-simple on backups page

### DIFF
--- a/lib/components/app.vue
+++ b/lib/components/app.vue
@@ -364,6 +364,7 @@ h1 {
 
     .panel-title {
       font-size: $font-size-table-heading;
+      line-height: inherit;
     }
   }
 

--- a/lib/components/backup/list.vue
+++ b/lib/components/backup/list.vue
@@ -10,94 +10,88 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div>
+  <div id="backup-list">
     <loading v-if="backups == null" :state="awaitingResponse"/>
-    <table v-else class="table">
-      <thead>
-        <tr>
-          <th colspan="3">Current Status</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td id="backup-list-status-icon-container">
-            <p><span :class="iconClasses"></span></p>
-          </td>
-          <td id="backup-list-status-message">
-            <template v-if="backups.status === 'notConfigured'">
-              <p>Backups are not configured.</p>
-              <p>
-                <strong>The data server has not been set up to automatically
-                back up its data anywhere.</strong>
-              </p>
-              <p>
-                Unless you have set up some other form of data backup that I
-                don’t know about, it is <strong>strongly recommended</strong>
-                that you do this now. If you are not sure, it is best to do it
-                just to be safe.
-              </p>
-              <p>
-                Automatic data backups happen through this system once a day.
-                All your data is encrypted with a password you provide so that
-                only you can unlock it.
-              </p>
-            </template>
-            <template v-else-if="backups.status === 'neverRun'">
-              <p>The configured backup has not yet run.</p>
-              <p>
-                If you have configured backups within the last couple of days,
-                this is normal. Otherwise, something has gone wrong.
-              </p>
-              <p>
-                In that case, the most likely fixes are to
-                <strong>terminate</strong> the connection and set it up again,
-                or to restart the service. If you are having trouble, please try
-                the
-                <a href="https://forum.opendatakit.org/" target="_blank">community forum</a>.
-              </p>
-            </template>
-            <template v-else-if="backups.status === 'somethingWentWrong'">
-              <p>Something is wrong!</p>
-              <p>
-                The latest backup that completed successfully was <strong>more
-                than three days ago.</strong>
-              </p>
-              <p>
-                The most likely fixes are to <strong>terminate</strong> the
-                connection and set it up again, or to restart the service. If
-                you are having trouble, please try the
-                <a href="https://forum.opendatakit.org/" target="_blank">community forum</a>.
-              </p>
-            </template>
-            <template v-else>
-              <p>Backup is working.</p>
-              <p>
-                The last backup completed successfully
-                <strong id="backup-list-most-recently-logged-at">
-                {{ mostRecentlyLoggedAt }}</strong>.
-              </p>
-            </template>
-          </td>
-          <td id="backup-list-button-container">
+    <div v-else class="panel panel-simple">
+      <div class="panel-heading">
+        <h1 class="panel-title">Current Status</h1>
+      </div>
+      <div class="panel-body">
+        <div id="backup-list-status-icon-container">
+          <span :class="iconClasses"></span>
+        </div>
+        <div id="backup-list-button-container">
+          <button v-if="backups.status == 'notConfigured'"
+            id="backup-list-new-button" type="button" class="btn btn-primary"
+            @click="showModal('newBackup')">
+            <span class="icon-plus-circle"></span> Set up now
+          </button>
+          <button v-else id="backup-list-terminate-button" type="button"
+            class="btn btn-primary" @click="showModal('terminate')">
+            <span class="icon-times-circle"></span> Terminate
+          </button>
+        </div>
+        <div id="backup-list-status-message">
+          <template v-if="backups.status === 'notConfigured'">
+            <p>Backups are not configured.</p>
             <p>
-              <button v-if="backups.status == 'notConfigured'"
-                id="backup-list-new-button" type="button"
-                class="btn btn-primary" @click="newBackup.state = true">
-                <span class="icon-plus-circle"></span> Set up now
-              </button>
-              <button v-else id="backup-list-terminate-button" type="button"
-                class="btn btn-primary" @click="terminate.state = true">
-                <span class="icon-times-circle"></span> Terminate
-              </button>
+              <strong>The data server has not been set up to automatically
+              back up its data anywhere.</strong>
             </p>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+            <p>
+              Unless you have set up some other form of data backup that I
+              don’t know about, it is <strong>strongly recommended</strong>
+              that you do this now. If you are not sure, it is best to do it
+              just to be safe.
+            </p>
+            <p>
+              Automatic data backups happen through this system once a day.
+              All your data is encrypted with a password you provide so that
+              only you can unlock it.
+            </p>
+          </template>
+          <template v-else-if="backups.status === 'neverRun'">
+            <p>The configured backup has not yet run.</p>
+            <p>
+              If you have configured backups within the last couple of days,
+              this is normal. Otherwise, something has gone wrong.
+            </p>
+            <p>
+              In that case, the most likely fixes are to
+              <strong>terminate</strong> the connection and set it up again,
+              or to restart the service. If you are having trouble, please try
+              the
+              <a href="https://forum.opendatakit.org/" target="_blank">community forum</a>.
+            </p>
+          </template>
+          <template v-else-if="backups.status === 'somethingWentWrong'">
+            <p>Something is wrong!</p>
+            <p>
+              The latest backup that completed successfully was <strong>more
+              than three days ago.</strong>
+            </p>
+            <p>
+              The most likely fixes are to <strong>terminate</strong> the
+              connection and set it up again, or to restart the service. If
+              you are having trouble, please try the
+              <a href="https://forum.opendatakit.org/" target="_blank">community forum</a>.
+            </p>
+          </template>
+          <template v-else>
+            <p>Backup is working.</p>
+            <p>
+              The last backup completed successfully
+              <strong id="backup-list-most-recently-logged-at">
+              {{ mostRecentlyLoggedAt }}</strong>.
+            </p>
+          </template>
+        </div>
+      </div>
+    </div>
 
-    <backup-new v-bind="newBackup" @hide="newBackup.state = false"
+    <backup-new v-bind="newBackup" @hide="hideModal('newBackup')"
       @success="afterCreate"/>
-    <backup-terminate v-bind="terminate" @hide="terminate.state = false"
+    <backup-terminate v-bind="terminate" @hide="hideModal('terminate')"
       @success="afterTerminate"/>
   </div>
 </template>
@@ -243,38 +237,37 @@ export default {
 <style lang="sass">
 @import '../../../assets/scss/variables';
 
-#backup-list-status-icon-container,
-#backup-list-status-message,
-#backup-list-button-container {
+$title-font-size: 28px;
+
+#backup-list .panel-body {
   padding-top: 10px;
 }
 
 #backup-list-status-icon-container {
-  padding-right: 5px;
-  width: 41px;
+  position: relative;
 
-  p {
+  span {
     font-size: 32px;
-
-    [class^="icon-"] {
-      vertical-align: 1px;
-    }
-  }
-}
-
-#backup-list-status-message, #backup-list-button-container {
-  p:first-child {
-    font-size: 28px;
-  }
-}
-
-#backup-list-status-message {
-  p {
-    max-width: 585px;
+    position: absolute;
+    top: 4px;
   }
 }
 
 #backup-list-button-container {
-  width: 113px;
+  float: right;
+  // Setting font-size to $title-font-size so that the button is vertically
+  // aligned correctly.
+  font-size: $title-font-size;
+}
+
+#backup-list-status-message {
+  p {
+    margin-left: 41px;
+    max-width: 585px;
+
+    &:first-child {
+      font-size: $title-font-size;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
The page does not contain table data, so we are replacing the table with
an identically designed panel. .panel-simple was added after the backups
page was created.

Closes #86.