### PR TITLE
Form state not form stage

### DIFF
--- a/lib/components/form/edit.vue
+++ b/lib/components/form/edit.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div id="form-edit" class="panel panel-simple">
-    <div class="panel-heading"><h1 class="panel-title">Form Stage</h1></div>
+    <div class="panel-heading"><h1 class="panel-title">Form State</h1></div>
     <div class="panel-body">
       <form>
         <fieldset :disabled="awaitingResponse">


### PR DESCRIPTION
Probably need a new screenshot at https://docs.opendatakit.org/central-forms/#managing-form-lifecycle but it can wait until v0.7.

I did not run this. I did a cursory check to see if 'stage' is used elsewhere in the frontend, but I'd appreciate a closer look.