### PR TITLE
Update luxon to fix failing test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8388,9 +8388,9 @@
       }
     },
     "luxon": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.15.0.tgz",
-      "integrity": "sha512-HIpK4zIonObWHj9UC80ElykmM/0jTuuXcbPYBYbDGZ3Cq2bL9rACcmppoc6zm5JnmHpnK5bRMIp8/+ei4O0y2Q=="
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.22.0.tgz",
+      "integrity": "sha512-3sLvlfbFo+AxVEY3IqxymbumtnlgBwjDExxK60W3d+trrUzErNAz/PfvPT+mva+vEUrdIodeCOs7fB6zHtRSrw=="
     },
     "make-dir": {
       "version": "2.1.0",


### PR DESCRIPTION
A `DateTime` was being formatted incorrectly, resulting in the failure of
a `SubmissionList` test. I am guessing that the test was failing today
because of the DST change.

I ran the following command:

`npm update luxon`